### PR TITLE
[refactor] Use single-instance of validator

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,7 +16,10 @@ func main() {
 	key := "/etc/webhook/certs/key.pem"
 	listenOn := "0.0.0.0:8443"
 
-	admissionController := &server.ImageValidationAdmission{}
+	admissionController, err := server.NewImageValidationAdmissionHandler()
+	if err != nil {
+		log.Fatal(err)
+	}
 	webhookServer := server.GetAdmissionValidationServer(admissionController, cert, key, listenOn)
 	if err := webhookServer.ListenAndServeTLS("", ""); err != nil {
 		log.Fatal(err)

--- a/deploy/deployment-dev.yaml
+++ b/deploy/deployment-dev.yaml
@@ -30,7 +30,4 @@ spec:
                 - name: webhook-certs
                   secret:
                     secretName: image-validation-admission-certs
-                - name: whitelist
-                  configMap:
-                    name: image-validation-webhook-whitelist                      
             serviceAccountName: image-validation-webhook

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -30,7 +30,4 @@ spec:
                 - name: webhook-certs
                   secret:
                     secretName: image-validation-admission-certs
-                - name: whitelist
-                  configMap:
-                    name: image-validation-webhook-whitelist                      
             serviceAccountName: image-validation-webhook

--- a/deploy/role/role.yaml
+++ b/deploy/role/role.yaml
@@ -28,6 +28,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -1,15 +1,36 @@
 package k8s
 
 import (
+	whv1 "github.com/tmax-cloud/image-validating-webhook/pkg/type"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 // NewClientSet initiates a new rest client set
-func NewClientSet() (*kubernetes.Clientset, error) {
+func NewClientSet() (*kubernetes.Clientset, rest.Interface, error) {
+	// Common client set
+	comCfg, err := config.GetConfig()
+	if err != nil {
+		return nil, nil, err
+	}
+	cliSet, err := kubernetes.NewForConfig(comCfg)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Rest client for tmax.io/v1
 	restCfg, err := config.GetConfig()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return kubernetes.NewForConfig(restCfg)
+	restCfg.ContentConfig.GroupVersion = &whv1.GroupVersion
+	restCfg.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	restCli, err := rest.RESTClientFor(restCfg)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return cliSet, restCli, nil
 }

--- a/internal/k8s/namespace.go
+++ b/internal/k8s/namespace.go
@@ -1,0 +1,34 @@
+package k8s
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+)
+
+// Namespace can retrieve current namespace
+func Namespace() (string, error) {
+	nsPath := "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+	if fileExists(nsPath) {
+		// Running in k8s cluster
+		nsBytes, err := ioutil.ReadFile(nsPath)
+		if err != nil {
+			return "", fmt.Errorf("could not read file %s", nsPath)
+		}
+		return string(nsBytes), nil
+	}
+	// Not running in k8s cluster (may be running locally)
+	ns := os.Getenv("NAMESPACE")
+	if ns == "" {
+		ns = "registry-system"
+	}
+	return ns, nil
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}

--- a/pkg/server/admission.go
+++ b/pkg/server/admission.go
@@ -19,7 +19,24 @@ const (
 )
 
 // ImageValidationAdmission is ...
-type ImageValidationAdmission struct{}
+type ImageValidationAdmission struct {
+	validator *validator
+}
+
+// NewImageValidationAdmissionHandler initiates a new image validation admission handler
+func NewImageValidationAdmissionHandler() (*ImageValidationAdmission, error) {
+	clientSet, restCli, err := k8s.NewClientSet()
+	if err != nil {
+		return nil, err
+	}
+
+	v, err := newValidator(clientSet, restCli, getFindHyperCloudNotaryServerFn(restCli))
+	if err != nil {
+		return nil, err
+	}
+
+	return &ImageValidationAdmission{validator: v}, nil
+}
 
 type patchOperation struct {
 	Op    string      `json:"op"`
@@ -41,46 +58,16 @@ func (a *ImageValidationAdmission) HandleAdmission(review *v1beta1.AdmissionRevi
 		return err
 	}
 
+	name := pod.Name
+	if name == "" {
+		name = pod.GenerateName
+	}
 	pod.Namespace = review.Request.Namespace
 
-	log.Printf("INFO: Start to handle review of pod %s in %s", pod.Name, pod.Namespace)
-
-	clientset, err := k8s.NewClientSet()
-	if err != nil {
-		log.Printf("ERROR: Couldn't make clientset by %s", err)
-		review.Response = &v1beta1.AdmissionResponse{
-			Allowed: false,
-			Result: &v1.Status{
-				Message: fmt.Sprintf("Internal webhook server error: %s", err),
-			},
-		}
-		return err
-	}
-
-	validator, err := newValidator(clientset, clientset.RESTClient(), getFindHyperCloudNotaryServerFn(clientset.RESTClient()), pod)
-	if err != nil {
-		log.Printf("ERROR: Couldn't make sign validator by %s", err)
-		review.Response = &v1beta1.AdmissionResponse{
-			Allowed: false,
-			Result: &v1.Status{
-				Message: fmt.Sprintf("Internal webhook server error: %s", err),
-			},
-		}
-		return err
-	}
-
-	// Check namespace whitelist
-	if validator.IsNamespaceInWhiteList(pod.Namespace) {
-		log.Println("INFO: This pod's namespace is in the white list")
-		review.Response = &v1beta1.AdmissionResponse{
-			Allowed: true,
-		}
-
-		return nil
-	}
+	log.Printf("INFO: Start to handle review of pod %s in %s", name, pod.Namespace)
 
 	// Validate image signers
-	isValid, name, err := validator.IsValid()
+	isValid, invalidImageName, err := a.validator.CheckIsValidAndAddDigest(pod)
 	if err != nil {
 		log.Printf("ERROR: Error while validating images by %s", err)
 		review.Response = &v1beta1.AdmissionResponse{
@@ -92,7 +79,7 @@ func (a *ImageValidationAdmission) HandleAdmission(review *v1beta1.AdmissionRevi
 		return err
 	} else if isValid {
 		log.Println("INFO: Pod is valid")
-		patch, err := createPatch(validator.GetPatch())
+		patch, err := createPatch(pod)
 		if err != nil {
 			log.Printf("ERROR: Couldn't make patched pod by %s", err)
 			review.Response = &v1beta1.AdmissionResponse{
@@ -116,7 +103,7 @@ func (a *ImageValidationAdmission) HandleAdmission(review *v1beta1.AdmissionRevi
 		review.Response = &v1beta1.AdmissionResponse{
 			Allowed: false,
 			Result: &v1.Status{
-				Message: fmt.Sprintf("Image '%s' is not signed", name),
+				Message: fmt.Sprintf("Image '%s' is not signed", invalidImageName),
 			},
 		}
 	}
@@ -125,14 +112,14 @@ func (a *ImageValidationAdmission) HandleAdmission(review *v1beta1.AdmissionRevi
 }
 
 func getFindHyperCloudNotaryServerFn(restClient restclient.Interface) findNotaryServerFn {
-	return func(registry, namespace string) string {
+	return func(registry string) string {
 		if registry == "docker.io" {
 			return ""
 		}
 
 		var targetReg *regv1.Registry
 		regList := &regv1.RegistryList{}
-		if err := restClient.Get().AbsPath("/apis/tmax.io/v1").Namespace(namespace).Resource("registries").Do(context.Background()).Into(regList); err != nil {
+		if err := restClient.Get().AbsPath("/apis/tmax.io/v1").Resource("registries").Do(context.Background()).Into(regList); err != nil {
 			log.Printf("reg list err %s", err)
 		}
 		for _, reg := range regList.Items {
@@ -153,7 +140,7 @@ func getFindHyperCloudNotaryServerFn(restClient restclient.Interface) findNotary
 
 func createPatch(patchPod *core.Pod) ([]byte, error) {
 	if patchPod == nil {
-		return nil, fmt.Errorf("Couldn't create patch")
+		return nil, fmt.Errorf("couldn't create patch")
 	}
 
 	patch := []patchOperation{

--- a/pkg/server/policy.go
+++ b/pkg/server/policy.go
@@ -1,0 +1,127 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	whv1 "github.com/tmax-cloud/image-validating-webhook/pkg/type"
+	regv1 "github.com/tmax-cloud/registry-operator/api/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	restclient "k8s.io/client-go/rest"
+	"log"
+	"sync"
+)
+
+// SignerPolicyCache is a cache of type.SignerPolicy
+type SignerPolicyCache struct {
+	policies map[string]map[string]*whv1.SignerPolicy
+
+	restClient restclient.Interface
+
+	lock sync.Mutex
+}
+
+func newSignerPolicyCache(restClient restclient.Interface) (*SignerPolicyCache, error) {
+	p := &SignerPolicyCache{
+		policies: map[string]map[string]*whv1.SignerPolicy{},
+
+		restClient: restClient,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// Start to watch SignerPolicy
+	go p.watch(&wg)
+
+	// Block until it's ready
+	wg.Wait()
+
+	return p, nil
+}
+
+func (c *SignerPolicyCache) watch(initWait *sync.WaitGroup) {
+	lastResourceVersions := map[string]string{}
+	// List first
+	sp := &whv1.SignerPolicyList{}
+	if err := c.restClient.Get().AbsPath("apis/tmax.io/v1").Resource("signerpolicies").Do(context.Background()).Into(sp); err != nil {
+		log.Fatal(err)
+	}
+
+	c.lock.Lock()
+	c.policies = map[string]map[string]*whv1.SignerPolicy{}
+	for _, p := range sp.Items {
+		if c.policies[p.Namespace] == nil {
+			c.policies[p.Namespace] = map[string]*whv1.SignerPolicy{}
+		}
+		log.Printf("SignerPolicy %s/%s is ADDED\n", p.Namespace, p.Name)
+		c.policies[p.Namespace][p.Name] = &p
+		lastResourceVersions[fmt.Sprintf("%s/%s", p.Namespace, p.Name)] = p.ResourceVersion
+	}
+	initWait.Done()
+	c.lock.Unlock()
+
+	// Watch forever
+	for {
+		w, err := c.restClient.Get().AbsPath("apis/tmax.io/v1").Resource("signerpolicies").Param("watch", "").Watch(context.Background())
+		if err != nil {
+			log.Println(err)
+			continue
+		}
+
+		for e := range w.ResultChan() {
+			policy, ok := e.Object.(*whv1.SignerPolicy)
+			if !ok {
+				continue
+			}
+
+			c.lock.Lock()
+			if c.policies[policy.Namespace] == nil {
+				c.policies[policy.Namespace] = map[string]*whv1.SignerPolicy{}
+			}
+
+			// Check resourceVersion - remove redundant processing
+			if lastResourceVersions[fmt.Sprintf("%s/%s", policy.Namespace, policy.Name)] == policy.ResourceVersion {
+				c.lock.Unlock()
+				continue
+			}
+
+			log.Printf("SignerPolicy %s/%s is %s\n", policy.Namespace, policy.Name, e.Type)
+			switch e.Type {
+			case watch.Added, watch.Modified:
+				c.policies[policy.Namespace][policy.Name] = policy
+			case watch.Deleted:
+				delete(c.policies[policy.Namespace], policy.Name)
+			}
+			lastResourceVersions[fmt.Sprintf("%s/%s", policy.Namespace, policy.Name)] = policy.ResourceVersion
+			c.lock.Unlock()
+		}
+	}
+}
+
+func (c *SignerPolicyCache) doesMatchPolicy(key, namespace string) bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// If no policy but is signed, it's valid
+	if len(c.policies[namespace]) == 0 {
+		return true
+	}
+
+	for _, signerPolicy := range c.policies[namespace] {
+		for _, signerName := range signerPolicy.Spec.Signers {
+			signer := &regv1.SignerKey{}
+			if err := c.restClient.Get().AbsPath("apis/tmax.io/v1").Resource("signerkeys").Name(signerName).Do(context.Background()).Into(signer); err != nil {
+				log.Printf("signer getting error by %s", err)
+				continue
+			}
+
+			for _, targetKey := range signer.Spec.Targets {
+				if targetKey.ID == key {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}

--- a/pkg/server/policy_test.go
+++ b/pkg/server/policy_test.go
@@ -1,0 +1,83 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/bmizerany/assert"
+	whv1 "github.com/tmax-cloud/image-validating-webhook/pkg/type"
+	regv1 "github.com/tmax-cloud/registry-operator/api/v1"
+	"io/ioutil"
+	"k8s.io/client-go/kubernetes/scheme"
+	restfake "k8s.io/client-go/rest/fake"
+	"net/http"
+	"testing"
+)
+
+type doesMatchPolicyTestCase struct {
+	key       string
+	namespace string
+
+	expectedMatch bool
+}
+
+func TestSignerPolicyCache_doesMatchPolicy(t *testing.T) {
+	tc := map[string]doesMatchPolicyTestCase{
+		"noPolicy": {
+			key:           "dummy",
+			namespace:     testNsNoPolicy,
+			expectedMatch: true,
+		},
+		"notMatchPolicy": {
+			key:           "no-match-key",
+			namespace:     testNsPolicy,
+			expectedMatch: false,
+		},
+		"matchPolicy": {
+			key:           "match-key",
+			namespace:     testNsPolicy,
+			expectedMatch: true,
+		},
+	}
+
+	cache := SignerPolicyCache{policies: map[string]map[string]*whv1.SignerPolicy{}, restClient: testPolicyRestClient()}
+
+	cache.policies[testNsPolicy] = map[string]*whv1.SignerPolicy{
+		"policy1": {
+			Spec: whv1.SignerPolicySpec{
+				Signers: []string{"signer1"},
+			},
+		},
+	}
+
+	for name, c := range tc {
+		t.Run(name, func(t *testing.T) {
+			match := cache.doesMatchPolicy(c.key, c.namespace)
+			assert.Equal(t, c.expectedMatch, match, "match policy")
+		})
+	}
+}
+
+func testPolicyRestClient() *restfake.RESTClient {
+	_ = whv1.AddToScheme(scheme.Scheme)
+	return &restfake.RESTClient{
+		GroupVersion:         whv1.GroupVersion,
+		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+		Client: restfake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			// SignerKeys
+			if sk := regSignerKeyPath.FindAllStringSubmatch(req.URL.Path, -1); len(sk) == 1 {
+				b, err := json.Marshal(&regv1.SignerKey{
+					Spec: regv1.SignerKeySpec{
+						Targets: map[string]regv1.TrustKey{
+							"dummyKey": {ID: "match-key"},
+						},
+					},
+				})
+				if err != nil {
+					return nil, err
+				}
+				return &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(bytes.NewReader(b))}, nil
+			}
+			return &http.Response{StatusCode: http.StatusNotFound, Body: ioutil.NopCloser(&bytes.Buffer{})}, nil
+		}),
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5,18 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"k8s.io/client-go/kubernetes/scheme"
 	"log"
 	"net/http"
 
 	"k8s.io/api/admission/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
-)
-
-var (
-	scheme = runtime.NewScheme()
-	codecs = serializer.NewCodecFactory(scheme)
 )
 
 // AdmissionController is ...
@@ -77,7 +72,7 @@ func GetAdmissionValidationServer(admissionController AdmissionController, tlsCe
 	mux := http.NewServeMux()
 	mux.Handle("/validate", &AdmissionControllerServer{
 		AdmissionController: admissionController,
-		Decoder:             codecs.UniversalDeserializer(),
+		Decoder:             scheme.Codecs.UniversalDeserializer(),
 	})
 
 	server := &http.Server{

--- a/pkg/server/signature.go
+++ b/pkg/server/signature.go
@@ -49,7 +49,13 @@ func (s *Signature) getRepoAdminKey() string {
 	return ""
 }
 
-func fetchSignature(img *image.Image, notaryServer string) (*Signature, error) {
+func fetchSignature(imageUri, basicAuth, notaryServer string) (*Signature, error) {
+	img, err := image.NewImage(imageUri, "", basicAuth, nil)
+	if err != nil {
+		log.Println(err)
+		return nil, err
+	}
+
 	// Use notary client
 	tempDir := fmt.Sprintf("%s/notary/%s", os.TempDir(), randomString(10))
 	not, err := trust.NewReadOnly(img, notaryServer, tempDir)

--- a/pkg/server/whitelist.go
+++ b/pkg/server/whitelist.go
@@ -5,14 +5,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"github.com/tmax-cloud/image-validating-webhook/internal/k8s"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
-	"os"
+	"log"
 	"regexp"
 	"strings"
+	"sync"
 )
 
 const (
@@ -29,102 +30,182 @@ const (
 	delimiter = "\n"
 )
 
-var whiteListDir = "/etc/webhook/config/"
-
 var whitelistImageReg = regexp.MustCompile(`^((([^./]+)\.([^/])+)/)?([^:@]+)(:([^@]+))?(@([^:]+:[0-9a-f]+))?`)
-
-func whitelistByImageFile() string {
-	return whiteListDir + whitelistByImage
-}
-
-func whitelistByNamespaceFile() string {
-	return whiteListDir + whitelistByNamespace
-}
-
-func whitelistByImageLegacyFile() string {
-	return whiteListDir + whitelistByImageLegacy
-}
-
-func whitelistByNamespaceLegacyFile() string {
-	return whiteListDir + whitelistByNamespaceLegacy
-}
-
-// ReadWhiteList reads whitelist from config map files
-func ReadWhiteList(clientSet kubernetes.Interface) (*WhiteList, error) {
-	wl := &WhiteList{}
-	// Read Image whitelist
-	imagef, err := ioutil.ReadFile(whitelistByImageFile())
-	if err != nil {
-		// If is NOT notFound, return error
-		if !os.IsNotExist(err) {
-			return nil, err
-		}
-
-		// Fallback to legacy
-		imageLegacyf, err := ioutil.ReadFile(whitelistByImageLegacyFile())
-		if err != nil {
-			return nil, err
-		}
-		if err := wl.UnmarshalLegacyImage(imageLegacyf); err != nil {
-			return nil, err
-		}
-
-		// Update ConfigMap!
-		converted, _ := wl.Marshal()
-		b, err := json.Marshal(&corev1.ConfigMap{Data: map[string]string{whitelistByImage: string(converted)}})
-		if err != nil {
-			return nil, err
-		}
-		if _, err := clientSet.CoreV1().ConfigMaps(registryNamespace).Patch(context.Background(), whitelistConfigMap, types.StrategicMergePatchType, b, metav1.PatchOptions{}); err != nil {
-			return nil, err
-		}
-	} else {
-		if err := wl.UnmarshalImage(imagef); err != nil {
-			return nil, err
-		}
-	}
-
-	// Read
-	namespacef, err := ioutil.ReadFile(whitelistByNamespaceFile())
-	if err != nil {
-		// If is NOT notFound, return error
-		if !os.IsNotExist(err) {
-			return nil, err
-		}
-
-		// Fallback to legacy
-		namespaceLegacyf, err := ioutil.ReadFile(whitelistByNamespaceLegacyFile())
-		if err != nil {
-			return nil, err
-		}
-		if err := wl.UnmarshalLegacyNamespace(namespaceLegacyf); err != nil {
-			return nil, err
-		}
-
-		// Update ConfigMap!
-		_, converted := wl.Marshal()
-		b, err := json.Marshal(&corev1.ConfigMap{Data: map[string]string{whitelistByNamespace: string(converted)}})
-		if err != nil {
-			return nil, err
-		}
-		if _, err := clientSet.CoreV1().ConfigMaps(registryNamespace).Patch(context.Background(), whitelistConfigMap, types.StrategicMergePatchType, b, metav1.PatchOptions{}); err != nil {
-			return nil, err
-		}
-	} else {
-		wl.UnmarshalNamespace(namespacef)
-	}
-
-	return wl, nil
-}
 
 // WhiteList stores whitelisted images/namespaces
 type WhiteList struct {
 	byImages     []imageRef
 	byNamespaces []string
+
+	client kubernetes.Interface
+
+	lock sync.Mutex
+}
+
+func newWhiteList(client kubernetes.Interface) (*WhiteList, error) {
+	wl := &WhiteList{
+		client: client,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// Start to watch white list config map
+	go wl.watch(&wg)
+
+	// Block until it's ready
+	wg.Wait()
+
+	return wl, nil
+}
+
+func (w *WhiteList) watch(initWait *sync.WaitGroup) {
+	ns, err := k8s.Namespace()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Get first
+	cm, err := w.client.CoreV1().ConfigMaps(ns).Get(context.Background(), whitelistConfigMap, metav1.GetOptions{})
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := w.ParseOrUpdateWhiteList(cm.Data, w.client); err != nil {
+		log.Fatal(err)
+	}
+
+	initWait.Done()
+
+	lastResourceVersion := cm.ResourceVersion
+	for {
+		// Watch
+		watcher, err := w.client.CoreV1().ConfigMaps(ns).Watch(context.Background(), metav1.ListOptions{FieldSelector: fmt.Sprintf("metadata.name=%s", whitelistConfigMap)})
+		if err != nil {
+			log.Println(err)
+			continue
+		}
+
+		for e := range watcher.ResultChan() {
+			cm, ok := e.Object.(*corev1.ConfigMap)
+			if !ok || cm.Name != whitelistConfigMap {
+				continue
+			}
+
+			// Check resourceVersion - remove redundant processing
+			if lastResourceVersion == cm.ResourceVersion {
+				continue
+			}
+
+			log.Println("Whitelist is updated")
+
+			if err := w.ParseOrUpdateWhiteList(cm.Data, w.client); err != nil {
+				log.Println(err)
+				continue
+			}
+
+			lastResourceVersion = cm.ResourceVersion
+		}
+	}
+}
+
+// ParseOrUpdateWhiteList reads whitelist from the config map data and updates it if it's still legacy
+func (w *WhiteList) ParseOrUpdateWhiteList(data map[string]string, clientSet kubernetes.Interface) error {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	// Read Image whitelist
+	imageWhiteList, iwExist := data[whitelistByImage]
+	if iwExist {
+		if err := w.UnmarshalImage(imageWhiteList); err != nil {
+			return err
+		}
+	} else {
+		// Fallback to legacy
+		imageWhiteListLegacy, exist := data[whitelistByImageLegacy]
+		if !exist {
+			return fmt.Errorf("there are neither %s nor %s in whitelist", whitelistByImage, whitelistByImageLegacy)
+		}
+		if err := w.UnmarshalLegacyImage(imageWhiteListLegacy); err != nil {
+			return err
+		}
+
+		// Update ConfigMap!
+		converted, _ := w.Marshal()
+		b, err := json.Marshal(&corev1.ConfigMap{Data: map[string]string{whitelistByImage: string(converted)}})
+		if err != nil {
+			return err
+		}
+		if _, err := clientSet.CoreV1().ConfigMaps(registryNamespace).Patch(context.Background(), whitelistConfigMap, types.StrategicMergePatchType, b, metav1.PatchOptions{}); err != nil {
+			return err
+		}
+	}
+
+	// Read Namespace whitelist
+	nsWhiteList, nwExist := data[whitelistByNamespace]
+	if nwExist {
+		w.UnmarshalNamespace(nsWhiteList)
+	} else {
+		// Fallback to legacy
+		nsWhiteListLegacy, exist := data[whitelistByNamespaceLegacy]
+		if !exist {
+			return fmt.Errorf("there are neither %s nor %s in whitelist", whitelistByNamespace, whitelistByNamespaceLegacy)
+		}
+		if err := w.UnmarshalLegacyNamespace(nsWhiteListLegacy); err != nil {
+			return err
+		}
+
+		// Update ConfigMap!
+		_, converted := w.Marshal()
+		b, err := json.Marshal(&corev1.ConfigMap{Data: map[string]string{whitelistByNamespace: string(converted)}})
+		if err != nil {
+			return err
+		}
+		if _, err := clientSet.CoreV1().ConfigMaps(registryNamespace).Patch(context.Background(), whitelistConfigMap, types.StrategicMergePatchType, b, metav1.PatchOptions{}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// IsNamespaceWhiteListed checks if ns is whitelisted
+func (w *WhiteList) IsNamespaceWhiteListed(ns string) bool {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	for _, whiteListNamespace := range w.byNamespaces {
+		if ns == whiteListNamespace {
+			return true
+		}
+	}
+	return false
+}
+
+// IsImageWhiteListed checks if an image is whitelisted
+func (w *WhiteList) IsImageWhiteListed(imageUri string) bool {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	img, err := parseImage(imageUri)
+	if err != nil {
+		log.Println(err)
+		return false
+	}
+
+	for _, i := range w.byImages {
+		match := (i.host == "" || i.host == img.host) &&
+			(i.name == "*" || i.name == img.name) &&
+			(i.tag == "" || i.tag == img.tag) &&
+			(i.digest == "" || i.digest == img.digest)
+
+		if match {
+			return true
+		}
+	}
+	return false
 }
 
 // Unmarshal parses whitelist lists from line-separated lists
-func (w *WhiteList) Unmarshal(img, ns []byte) error {
+func (w *WhiteList) Unmarshal(img, ns string) error {
 	// Parse byImages
 	if err := w.UnmarshalImage(img); err != nil {
 		return err
@@ -135,7 +216,7 @@ func (w *WhiteList) Unmarshal(img, ns []byte) error {
 }
 
 // UnmarshalImage parses image whitelist from line-separated lists
-func (w *WhiteList) UnmarshalImage(img []byte) error {
+func (w *WhiteList) UnmarshalImage(img string) error {
 	var err error
 	w.byImages, err = parseImages(parseLineSeparatedList(img))
 	if err != nil {
@@ -145,21 +226,21 @@ func (w *WhiteList) UnmarshalImage(img []byte) error {
 }
 
 // UnmarshalNamespace parses namespace whitelist from line-separated lists
-func (w *WhiteList) UnmarshalNamespace(ns []byte) {
+func (w *WhiteList) UnmarshalNamespace(ns string) {
 	w.byNamespaces = parseLineSeparatedList(ns)
 }
 
 // Marshal generates whitelist byte arrays from lists
-func (w *WhiteList) Marshal() ([]byte, []byte) {
+func (w *WhiteList) Marshal() (string, string) {
 	var images []string
 	for _, i := range w.byImages {
 		images = append(images, i.String())
 	}
-	return []byte(strings.Join(images, delimiter)), []byte(strings.Join(w.byNamespaces, delimiter))
+	return strings.Join(images, delimiter), strings.Join(w.byNamespaces, delimiter)
 }
 
 // UnmarshalLegacy parses whitelist lists from json array
-func (w *WhiteList) UnmarshalLegacy(img, ns []byte) error {
+func (w *WhiteList) UnmarshalLegacy(img, ns string) error {
 	// Parse byImages
 	if err := w.UnmarshalLegacyImage(img); err != nil {
 		return err
@@ -172,10 +253,10 @@ func (w *WhiteList) UnmarshalLegacy(img, ns []byte) error {
 }
 
 // UnmarshalLegacyImage parses image whitelist from json array
-func (w *WhiteList) UnmarshalLegacyImage(img []byte) error {
+func (w *WhiteList) UnmarshalLegacyImage(img string) error {
 	var err error
 	var byImages []string
-	if err := json.Unmarshal(img, &byImages); err != nil {
+	if err := json.Unmarshal([]byte(img), &byImages); err != nil {
 		return err
 	}
 
@@ -187,14 +268,14 @@ func (w *WhiteList) UnmarshalLegacyImage(img []byte) error {
 }
 
 // UnmarshalLegacyNamespace parses namespace whitelist from json array
-func (w *WhiteList) UnmarshalLegacyNamespace(ns []byte) error {
-	return json.Unmarshal(ns, &w.byNamespaces)
+func (w *WhiteList) UnmarshalLegacyNamespace(ns string) error {
+	return json.Unmarshal([]byte(ns), &w.byNamespaces)
 }
 
-func parseLineSeparatedList(list []byte) []string {
+func parseLineSeparatedList(list string) []string {
 	var result []string
 
-	tokens := strings.Split(string(list), delimiter)
+	tokens := strings.Split(list, delimiter)
 	for _, line := range tokens {
 		trimmed := strings.TrimSpace(line)
 		if trimmed != "" {

--- a/pkg/type/signerpolicy_types.go
+++ b/pkg/type/signerpolicy_types.go
@@ -4,6 +4,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func init() {
+	SchemeBuilder.Register(&SignerPolicy{}, &SignerPolicyList{})
+}
+
 // SignerPolicySpec is a spec of SignerPolicy
 type SignerPolicySpec struct {
 	Signers []string `json:"signers"`


### PR DESCRIPTION
# Changes
<!--
Describe the changes of the pull request
-->
- Use single instance of validator, which is created when the admission
  controller is created, instead of creating it each time it is called
- Watch SignerPolicies to sync policy updates
- Watch whitelist ConfigMap, instead of mounting as files

# Submitter Checklist
<!--
Please check the following checklist before submitting

You can check an item like:
- [x] Docs
-->

- [ ] Docs included if needed
- [x] Tests included if needed
- [x] Follows the [good commit messages standard](https://chris.beams.io/posts/git-commit/) 
