### PR TITLE
[feat] Add client-go cache based object watcher

### DIFF
--- a/pkg/watcher/cachedclient.go
+++ b/pkg/watcher/cachedclient.go
@@ -1,0 +1,102 @@
+package watcher
+
+import (
+	"fmt"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+	"reflect"
+	"sort"
+)
+
+// CachedClient is a reader from the cache
+type CachedClient interface {
+	Get(types.NamespacedName, runtime.Object) error
+	List(Selector, runtime.Object) error
+}
+
+type cachedClient struct {
+	indexer cache.Indexer
+}
+
+// NewCachedClient creates a cache reader client from the given Watcher
+func NewCachedClient(w Watcher) CachedClient {
+	return &cachedClient{indexer: w.getIndexer()}
+}
+
+func (g *cachedClient) Get(key types.NamespacedName, out runtime.Object) error {
+	keyStr := ""
+	if key.Namespace != "" {
+		keyStr += key.Namespace + string(types.Separator)
+	}
+	keyStr += key.Name
+
+	// Get from cache
+	obj, exists, _ := g.indexer.GetByKey(keyStr)
+	if !exists {
+		return errors.NewNotFound(schema.GroupResource{}, key.Name)
+	}
+
+	// Check if it's runtime object
+	if _, isObj := obj.(runtime.Object); !isObj {
+		// This should never happen
+		return fmt.Errorf("cache contained %T, which is not an Object", obj)
+	}
+
+	obj = obj.(runtime.Object).DeepCopyObject()
+
+	outVal := reflect.ValueOf(out)
+	objVal := reflect.ValueOf(obj)
+	if !objVal.Type().AssignableTo(outVal.Type()) {
+		return fmt.Errorf("cache had type %s, but %s was asked for", objVal.Type(), outVal.Type())
+	}
+	reflect.Indirect(outVal).Set(reflect.Indirect(objVal))
+
+	return nil
+}
+
+func (g *cachedClient) List(sel Selector, out runtime.Object) error {
+	var err error
+	var objs []interface{}
+
+	if sel.Namespace != "" {
+		objs, err = g.indexer.ByIndex(cache.NamespaceIndex, sel.Namespace)
+		if err != nil {
+			return err
+		}
+	} else {
+		objs = g.indexer.List()
+	}
+
+	sort.Slice(objs, func(i, j int) bool {
+		aMeta, err := apimeta.Accessor(objs[i])
+		if err != nil {
+			return false
+		}
+		bMeta, err := apimeta.Accessor(objs[j])
+		if err != nil {
+			return false
+		}
+
+		return fmt.Sprintf("%s/%s", aMeta.GetNamespace(), aMeta.GetName()) < fmt.Sprintf("%s/%s", bMeta.GetNamespace(), bMeta.GetName())
+	})
+
+	runtimeObjs := make([]runtime.Object, 0, len(objs))
+	for _, item := range objs {
+		obj, isObj := item.(runtime.Object)
+		if !isObj {
+			return fmt.Errorf("cache contained %T, which is not an Object", obj)
+		}
+		runtimeObjs = append(runtimeObjs, obj.DeepCopyObject())
+	}
+	return meta.SetList(out, runtimeObjs)
+}
+
+// Selector is an object-selector for list methods
+type Selector struct {
+	Namespace string
+}

--- a/pkg/watcher/cachedclient_test.go
+++ b/pkg/watcher/cachedclient_test.go
@@ -1,0 +1,164 @@
+package watcher
+
+import (
+	"github.com/bmizerany/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+	"reflect"
+	"testing"
+)
+
+type testCachedClientGetCase struct {
+	objs []runtime.Object
+
+	getKey       types.NamespacedName
+	expectedObj  runtime.Object
+	errorOccurs  bool
+	errorMessage string
+}
+
+func TestCachedClient_Get(t *testing.T) {
+	tc := map[string]testCachedClientGetCase{
+		"pods": {
+			objs: []runtime.Object{
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test"}}}},
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test2", Namespace: "default"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test2"}}}},
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "controller", Namespace: "kube-system"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "controller"}}}},
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "api-server", Namespace: "kube-system"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "api-server"}}}},
+			},
+			getKey:      types.NamespacedName{Name: "test2", Namespace: "default"},
+			expectedObj: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test2", Namespace: "default"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test2"}}}},
+			errorOccurs: false,
+		},
+		"pods2": {
+			objs: []runtime.Object{
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test"}}}},
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test2", Namespace: "default"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test2"}}}},
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "controller", Namespace: "kube-system"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "controller"}}}},
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "api-server", Namespace: "kube-system"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "api-server"}}}},
+			},
+			getKey:      types.NamespacedName{Name: "controller", Namespace: "kube-system"},
+			expectedObj: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "controller", Namespace: "kube-system"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "controller"}}}},
+			errorOccurs: false,
+		},
+		"podsNotFound": {
+			objs: []runtime.Object{
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test"}}}},
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test2", Namespace: "default"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test2"}}}},
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "controller", Namespace: "kube-system"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "controller"}}}},
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "api-server", Namespace: "kube-system"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "api-server"}}}},
+			},
+			getKey:       types.NamespacedName{Name: "controller2", Namespace: "kube-system"},
+			expectedObj:  &corev1.Pod{},
+			errorOccurs:  true,
+			errorMessage: " \"controller2\" not found",
+		},
+	}
+
+	for name, c := range tc {
+		t.Run(name, func(t *testing.T) {
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			for _, o := range c.objs {
+				if err := indexer.Add(o); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			cc := &cachedClient{indexer: indexer}
+
+			out := c.expectedObj.DeepCopyObject()
+			err := cc.Get(c.getKey, out)
+			if err != nil {
+				assert.Equal(t, c.errorOccurs, true, "error occurs")
+				assert.Equal(t, c.errorMessage, err.Error(), "error message")
+			} else {
+				assert.Equal(t, c.errorOccurs, false, "error occurs")
+				assert.Equal(t, true, reflect.DeepEqual(c.expectedObj, out), "out object")
+			}
+		})
+	}
+}
+
+type testCachedClientListCase struct {
+	objs []runtime.Object
+
+	namespaceKey       string
+	errorOccurs        bool
+	errorMessage       string
+	expectedObjectList runtime.Object
+}
+
+func TestCachedClient_List(t *testing.T) {
+	tc := map[string]testCachedClientListCase{
+		"podsAll": {
+			objs: []runtime.Object{
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test"}}}},
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test2", Namespace: "default"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test2"}}}},
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "api-server", Namespace: "kube-system"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "api-server"}}}},
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "controller", Namespace: "kube-system"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "controller"}}}},
+			},
+			namespaceKey: "",
+			expectedObjectList: &corev1.PodList{Items: []corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test"}}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "test2", Namespace: "default"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test2"}}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "api-server", Namespace: "kube-system"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "api-server"}}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "controller", Namespace: "kube-system"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "controller"}}}},
+			}},
+			errorOccurs: false,
+		},
+		"podsDefault": {
+			objs: []runtime.Object{
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test"}}}},
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test2", Namespace: "default"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test2"}}}},
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "api-server", Namespace: "kube-system"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "api-server"}}}},
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "controller", Namespace: "kube-system"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "controller"}}}},
+			},
+			namespaceKey: "default",
+			expectedObjectList: &corev1.PodList{Items: []corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test"}}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "test2", Namespace: "default"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test2"}}}},
+			}},
+			errorOccurs: false,
+		},
+		"podsSystem": {
+			objs: []runtime.Object{
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test"}}}},
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test2", Namespace: "default"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test2"}}}},
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "api-server", Namespace: "kube-system"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "api-server"}}}},
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "controller", Namespace: "kube-system"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "controller"}}}},
+			},
+			namespaceKey: "kube-system",
+			expectedObjectList: &corev1.PodList{Items: []corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "api-server", Namespace: "kube-system"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "api-server"}}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "controller", Namespace: "kube-system"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "controller"}}}},
+			}},
+			errorOccurs: false,
+		},
+	}
+
+	for name, c := range tc {
+		t.Run(name, func(t *testing.T) {
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			for _, o := range c.objs {
+				if err := indexer.Add(o); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			cc := &cachedClient{indexer: indexer}
+
+			out := c.expectedObjectList.DeepCopyObject()
+			err := cc.List(Selector{Namespace: c.namespaceKey}, out)
+			if err != nil {
+				assert.Equal(t, c.errorOccurs, true, "error occurs")
+				assert.Equal(t, c.errorMessage, err.Error(), "error message")
+			} else {
+				assert.Equal(t, c.errorOccurs, false, "error occurs")
+				assert.Equal(t, true, reflect.DeepEqual(c.expectedObjectList, out), "out object")
+			}
+		})
+	}
+}

--- a/pkg/watcher/fake/cachedclient.go
+++ b/pkg/watcher/fake/cachedclient.go
@@ -1,0 +1,72 @@
+package fake
+
+import (
+	"fmt"
+	"github.com/tmax-cloud/image-validating-webhook/pkg/watcher"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+// CachedClient is a fake watcher.CachedClient for testing
+type CachedClient struct {
+	Cache map[string]runtime.Object
+}
+
+// Get gets an object from the cache
+func (c *CachedClient) Get(key types.NamespacedName, out runtime.Object) error {
+	keyStr := ""
+	if key.Namespace != "" {
+		keyStr += key.Namespace + "/"
+	}
+	keyStr += key.Name
+
+	obj, ok := c.Cache[keyStr]
+	if !ok {
+		return fmt.Errorf("not found")
+	}
+
+	obj = obj.(runtime.Object).DeepCopyObject()
+
+	outVal := reflect.ValueOf(out)
+	objVal := reflect.ValueOf(obj)
+	if !objVal.Type().AssignableTo(outVal.Type()) {
+		return fmt.Errorf("cache had type %s, but %s was asked for", objVal.Type(), outVal.Type())
+	}
+	reflect.Indirect(outVal).Set(reflect.Indirect(objVal))
+
+	return nil
+}
+
+// List lists objects from the cache
+func (c *CachedClient) List(sel watcher.Selector, out runtime.Object) error {
+	var objs []runtime.Object
+	for k, obj := range c.Cache {
+		if sel.Namespace == "" || strings.HasPrefix(k, fmt.Sprintf("%s/", sel.Namespace)) {
+			objs = append(objs, obj)
+		}
+	}
+
+	sort.Slice(objs, func(i, j int) bool {
+		aMeta, err := apimeta.Accessor(objs[i])
+		if err != nil {
+			return false
+		}
+		bMeta, err := apimeta.Accessor(objs[j])
+		if err != nil {
+			return false
+		}
+
+		return fmt.Sprintf("%s/%s", aMeta.GetNamespace(), aMeta.GetName()) < fmt.Sprintf("%s/%s", bMeta.GetNamespace(), bMeta.GetName())
+	})
+
+	runtimeObjs := make([]runtime.Object, 0, len(objs))
+	for _, obj := range objs {
+		outObj := obj.DeepCopyObject()
+		runtimeObjs = append(runtimeObjs, outObj)
+	}
+	return apimeta.SetList(out, runtimeObjs)
+}

--- a/pkg/watcher/fake/cachedclient_test.go
+++ b/pkg/watcher/fake/cachedclient_test.go
@@ -1,0 +1,154 @@
+package fake
+
+import (
+	"github.com/bmizerany/assert"
+	whv1 "github.com/tmax-cloud/image-validating-webhook/pkg/type"
+	"github.com/tmax-cloud/image-validating-webhook/pkg/watcher"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"reflect"
+	"testing"
+)
+
+type testCachedClientGetTestCase struct {
+	cacheMap map[string]runtime.Object
+
+	key types.NamespacedName
+
+	errorOccurs    bool
+	errorMessage   string
+	expectedObject runtime.Object
+}
+
+func TestCachedClient_Get(t *testing.T) {
+	tc := map[string]testCachedClientGetTestCase{
+		"pod": {
+			cacheMap: map[string]runtime.Object{
+				"default/test": &corev1.Pod{
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test"}}},
+				},
+			},
+			key:         types.NamespacedName{Name: "test", Namespace: "default"},
+			errorOccurs: false,
+			expectedObject: &corev1.Pod{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test"}}},
+			},
+		},
+		"configmap": {
+			cacheMap: map[string]runtime.Object{
+				"default/test": &corev1.ConfigMap{
+					Data: map[string]string{"testKey": "testVal"},
+				},
+			},
+			key:         types.NamespacedName{Name: "test", Namespace: "default"},
+			errorOccurs: false,
+			expectedObject: &corev1.ConfigMap{
+				Data: map[string]string{"testKey": "testVal"},
+			},
+		},
+		"signerPolicy": {
+			cacheMap: map[string]runtime.Object{
+				"default/test": &whv1.SignerPolicy{
+					Spec: whv1.SignerPolicySpec{Signers: []string{"test-signer"}},
+				},
+			},
+			key:         types.NamespacedName{Name: "test", Namespace: "default"},
+			errorOccurs: false,
+			expectedObject: &whv1.SignerPolicy{
+				Spec: whv1.SignerPolicySpec{Signers: []string{"test-signer"}},
+			},
+		},
+		"notFound": {
+			cacheMap: map[string]runtime.Object{
+				"default/test": &corev1.ConfigMap{
+					Data: map[string]string{"testKey": "testVal"},
+				},
+			},
+			key:          types.NamespacedName{Name: "not-found", Namespace: "default"},
+			errorOccurs:  true,
+			errorMessage: "not found",
+			expectedObject: &corev1.ConfigMap{
+				Data: map[string]string{"testKey": "testVal"},
+			},
+		},
+	}
+
+	for name, c := range tc {
+		t.Run(name, func(t *testing.T) {
+			cli := &CachedClient{Cache: c.cacheMap}
+
+			out := c.expectedObject.DeepCopyObject()
+			err := cli.Get(c.key, out)
+			if err != nil {
+				assert.Equal(t, c.errorOccurs, true, "error occurs")
+				assert.Equal(t, c.errorMessage, err.Error(), "error message")
+			} else {
+				assert.Equal(t, c.errorOccurs, false, "error occurs")
+				assert.Equal(t, true, reflect.DeepEqual(out, c.expectedObject), "deep equal output")
+			}
+		})
+	}
+}
+
+type testCachedClientListCase struct {
+	cacheMap map[string]runtime.Object
+
+	namespaceKey       string
+	errorOccurs        bool
+	errorMessage       string
+	expectedObjectList runtime.Object
+}
+
+func TestCachedClient_List(t *testing.T) {
+	tc := map[string]testCachedClientListCase{
+		"podsAll": {
+			cacheMap: map[string]runtime.Object{
+				"default/test":  &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test"}}}},
+				"default/test2": &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test2", Namespace: "default"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test2"}}}},
+				"test/test2":    &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test2", Namespace: "test"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test23"}}}},
+			},
+			namespaceKey: "",
+			errorOccurs:  false,
+			expectedObjectList: &corev1.PodList{
+				Items: []corev1.Pod{
+					{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test"}}}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "test2", Namespace: "default"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test2"}}}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "test2", Namespace: "test"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test23"}}}},
+				},
+			},
+		},
+		"podsDefault": {
+			cacheMap: map[string]runtime.Object{
+				"default/test":  &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test"}}}},
+				"default/test2": &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test2", Namespace: "default"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test2"}}}},
+				"test/test2":    &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test2", Namespace: "test"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test23"}}}},
+			},
+			namespaceKey: "default",
+			errorOccurs:  false,
+			expectedObjectList: &corev1.PodList{
+				Items: []corev1.Pod{
+					{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test"}}}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "test2", Namespace: "default"}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "test2"}}}},
+				},
+			},
+		},
+	}
+
+	for name, c := range tc {
+		t.Run(name, func(t *testing.T) {
+			cli := &CachedClient{Cache: c.cacheMap}
+
+			out := c.expectedObjectList.DeepCopyObject()
+			err := cli.List(watcher.Selector{Namespace: c.namespaceKey}, out)
+			if err != nil {
+				assert.Equal(t, c.errorOccurs, true, "error occurs")
+				assert.Equal(t, c.errorMessage, err.Error(), "error message")
+			} else {
+				assert.Equal(t, c.errorOccurs, false, "error occurs")
+				assert.Equal(t, true, reflect.DeepEqual(out, c.expectedObjectList), "deep equal output")
+			}
+		})
+	}
+}

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -1,0 +1,140 @@
+package watcher
+
+import (
+	"fmt"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"log"
+	"time"
+)
+
+// Handler an interface for watch events
+type Handler interface {
+	Handle(runtime.Object) error
+}
+
+// Watcher is an interface of k8s object watcher
+type Watcher interface {
+	Start(chan struct{})
+	SetHandler(Handler)
+
+	getIndexer() cache.Indexer
+}
+
+type watcher struct {
+	queue    workqueue.RateLimitingInterface
+	indexer  cache.Indexer
+	informer cache.Controller
+
+	stopCh chan struct{}
+
+	handler Handler
+}
+
+// New creates a new watcher for the given object
+func New(namespace, resourceKind string, obj runtime.Object, restCli rest.Interface, selector fields.Selector) Watcher {
+	listWatcher := cache.NewListWatchFromClient(restCli, resourceKind, namespace, selector)
+	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+
+	//cache.NewSharedIndexInformer()
+	indexer, informer := cache.NewIndexerInformer(listWatcher, obj, 0, cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			key, err := cache.MetaNamespaceKeyFunc(obj)
+			if err == nil {
+				queue.Add(key)
+			}
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			key, err := cache.MetaNamespaceKeyFunc(newObj)
+			if err == nil {
+				queue.Add(key)
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+			if err == nil {
+				queue.Add(key)
+			}
+		},
+	}, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+
+	w := &watcher{
+		queue:    queue,
+		indexer:  indexer,
+		informer: informer,
+
+		stopCh: make(chan struct{}),
+	}
+
+	return w
+}
+
+func (w *watcher) Start(waitCh chan struct{}) {
+	// Start informer sync
+	go w.informer.Run(w.stopCh)
+
+	// Wait until cache is synced
+	if !cache.WaitForCacheSync(w.stopCh, w.informer.HasSynced) {
+		panic(fmt.Errorf("timed out waiting for caches to sync"))
+	}
+
+	waitCh <- struct{}{}
+
+	// Start watcher func
+	wait.Until(w.watch, time.Second, w.stopCh)
+}
+
+func (w *watcher) SetHandler(handler Handler) {
+	w.handler = handler
+}
+
+func (w *watcher) getIndexer() cache.Indexer {
+	return w.indexer
+}
+
+func (w *watcher) watch() {
+	for w.processNextItem() {
+	}
+}
+
+func (w *watcher) processNextItem() bool {
+	key, quit := w.queue.Get()
+	if quit {
+		return false
+	}
+
+	defer w.queue.Done(key)
+
+	keyStr, ok := key.(string)
+	if !ok {
+		log.Println("key is not a string")
+		return true
+	}
+
+	// Get from cache
+	obj, exists, _ := w.indexer.GetByKey(keyStr)
+	if !exists {
+		log.Printf("resource %s not found\n", keyStr)
+		return true
+	}
+
+	// Check if it's runtime object
+	rObj, isObj := obj.(runtime.Object)
+	if !isObj {
+		log.Printf("cache contained %T, which is not an Object\n", obj)
+		return true
+	}
+
+	if w.handler != nil {
+		if err := w.handler.Handle(rObj.DeepCopyObject()); err != nil {
+			log.Println(err)
+			return true
+		}
+	}
+
+	return true
+}

--- a/pkg/watcher/watcher_test.go
+++ b/pkg/watcher/watcher_test.go
@@ -1,0 +1,189 @@
+package watcher
+
+import (
+	"bytes"
+	"github.com/bmizerany/assert"
+	whv1 "github.com/tmax-cloud/image-validating-webhook/pkg/type"
+	"io/ioutil"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	restfake "k8s.io/client-go/rest/fake"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	cli := testWatcherRestClient()
+	wi := New("", "", &corev1.Pod{}, cli, fields.Everything())
+
+	w, ok := wi.(*watcher)
+	assert.Equal(t, true, ok, "assertion")
+
+	// Queue test
+	t.Run("queue", func(t *testing.T) {
+		assert.Equal(t, true, w.queue != nil, "queue")
+
+		assert.Equal(t, 0, w.queue.Len(), "len")
+		w.queue.Add(&corev1.Pod{Spec: corev1.PodSpec{SchedulerName: "test"}})
+		assert.Equal(t, 1, w.queue.Len(), "len")
+		obj, quit := w.queue.Get()
+		assert.Equal(t, false, quit, "quit")
+		pod, ok := obj.(*corev1.Pod)
+		assert.Equal(t, true, ok, "assertion")
+		assert.Equal(t, "test", pod.Spec.SchedulerName, "testVal")
+		w.queue.Done(obj)
+		assert.Equal(t, 0, w.queue.Len(), "len")
+	})
+
+	// Indexer test
+	t.Run("indexer", func(t *testing.T) {
+		assert.Equal(t, true, w.indexer != nil, "indexer")
+
+		pods := []*corev1.Pod{
+			{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}, Spec: corev1.PodSpec{SchedulerName: "test-1"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "test2", Namespace: "default"}, Spec: corev1.PodSpec{SchedulerName: "test-2"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "kube-system"}, Spec: corev1.PodSpec{SchedulerName: "system-1"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "test2", Namespace: "kube-system"}, Spec: corev1.PodSpec{SchedulerName: "system-2"}},
+		}
+		for _, pod := range pods {
+			if err := w.indexer.Add(pod); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		t.Run("namespaceIndex", func(t *testing.T) {
+			type testCase struct {
+				key string
+				val string
+
+				errorOccurs  bool
+				errorMessage string
+				expectedLen  int
+			}
+
+			tc := map[string]testCase{
+				"namespaceDefault": {
+					key:         "namespace",
+					val:         "default",
+					errorOccurs: false,
+					expectedLen: 2,
+				},
+				"namespaceSystem": {
+					key:         "namespace",
+					val:         "kube-system",
+					errorOccurs: false,
+					expectedLen: 2,
+				},
+				"namespaceTest": {
+					key:         "namespace",
+					val:         "test",
+					errorOccurs: false,
+					expectedLen: 0,
+				},
+			}
+
+			for name, c := range tc {
+				t.Run(name, func(t *testing.T) {
+					objs, err := w.indexer.ByIndex(c.key, c.val)
+					if err != nil {
+						assert.Equal(t, c.errorOccurs, true, "error occurs")
+						assert.Equal(t, c.errorMessage, "", "error message")
+					} else {
+						assert.Equal(t, c.errorOccurs, false, "error occurs")
+						assert.Equal(t, c.expectedLen, len(objs), "len")
+					}
+				})
+			}
+		})
+	})
+
+	// Informer test
+	t.Run("informer", func(t *testing.T) {
+		assert.Equal(t, true, w.informer != nil, "informer")
+		assert.Equal(t, false, w.informer.HasSynced(), "synced")
+	})
+}
+
+type testWatcherHandler struct {
+	obj runtime.Object
+}
+
+func (t *testWatcherHandler) Handle(object runtime.Object) error {
+	t.obj = object
+	return nil
+}
+
+func TestWatcher_SetHandler(t *testing.T) {
+	cli := testWatcherRestClient()
+	wi := New("", "", &corev1.Pod{}, cli, fields.Everything())
+
+	hdl := &testWatcherHandler{}
+
+	w, ok := wi.(*watcher)
+	assert.Equal(t, true, ok, "assertion")
+
+	wi.SetHandler(hdl)
+	assert.Equal(t, true, w.handler != nil, "handler")
+
+	pod := &corev1.Pod{Spec: corev1.PodSpec{SchedulerName: "test-sche"}}
+	if err := w.handler.Handle(pod); err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, true, reflect.DeepEqual(pod, hdl.obj), "deep equal")
+}
+
+func TestWatcher_GetClient(t *testing.T) {
+	cli := testWatcherRestClient()
+	wi := New("", "", &corev1.Pod{}, cli, fields.Everything())
+
+	w, ok := wi.(*watcher)
+	assert.Equal(t, true, ok, "assertion")
+
+	pods := []*corev1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}, Spec: corev1.PodSpec{SchedulerName: "test"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "test2", Namespace: "default"}, Spec: corev1.PodSpec{SchedulerName: "test2"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "test1", Namespace: "kube-system"}, Spec: corev1.PodSpec{SchedulerName: "system-1"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "test2", Namespace: "kube-system"}, Spec: corev1.PodSpec{SchedulerName: "system-2"}},
+	}
+	for _, pod := range pods {
+		if err := w.indexer.Add(pod); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	c := NewCachedClient(w)
+
+	pod := &corev1.Pod{}
+	if err := c.Get(types.NamespacedName{Name: "test", Namespace: "default"}, pod); err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "test", pod.Spec.SchedulerName, "test val")
+
+	if err := c.Get(types.NamespacedName{Name: "test3", Namespace: "default"}, pod); err == nil {
+		t.Fatal("not found error should occur")
+	}
+}
+
+func TestWatcher_Start(t *testing.T) {
+	cli := testWatcherRestClient()
+	wi := New("", "", &corev1.Pod{}, cli, fields.Everything())
+
+	go wi.Start(nil)
+
+	// TODO
+}
+
+func testWatcherRestClient() *restfake.RESTClient {
+	return &restfake.RESTClient{
+		GroupVersion:         whv1.GroupVersion,
+		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+		Client: restfake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusNotFound, Body: ioutil.NopCloser(&bytes.Buffer{})}, nil
+		}),
+	}
+}


### PR DESCRIPTION
# Changes
<!--
Describe the changes of the pull request
-->
- Part of #29
- This commit only adds a `Watcher` feature, based on the client-go
  cache, but does NOT replace current object-watch features.

# Submitter Checklist
<!--
Please check the following checklist before submitting

You can check an item like:
- [x] Docs
-->

- [ ] Docs included if needed
- [x] Tests included if needed
- [x] Follows the [good commit messages standard](https://chris.beams.io/posts/git-commit/) 
